### PR TITLE
Add credentials for MQTT and make entity editable in Home Assistant UI

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -33,6 +33,8 @@ docker run -p 53:53/udp -p 53:53/tcp -p 80:80 -p 443:443 -p 8883:8883 -p 26268:2
   --ntp-addr <NTP_IP> \
   --ha-mqtt-addr <HA_MQTT_IP> \
   --ha-mqtt-topic-prefix <HA_MQTT_TOPIC_PREFIX> \
+  --ha-mqtt-username <HA_MQTT_USERNAME> \
+  --ha-mqtt-password <HA_MQTT_PASSWORD> \
   --client-id <THERMOSTAT_DEVICE_ID>
 ```
 
@@ -54,6 +56,8 @@ services:
       --ntp-addr 192.168.1.1
       --ha-mqtt-addr 192.168.1.100
       --ha-mqtt-topic-prefix hvac/carrier
+      --ha-mqtt-username HA_MQTT_USERNAME
+      --ha-mqtt-password HA_MQTT_PASSWORD
       --client-id YOUR_THERMOSTAT_ID
     restart: unless-stopped
 ```

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ anantha serve \
   --ntp-addr <NTP_IP> \                           # NTP server IP (e.g., 192.168.86.1)
   --ha-mqtt-addr <HA_MQTT_IP> \                   # Home Assistant MQTT server IP
   --ha-mqtt-topic-prefix <HA_MQTT_TOPIC_PREFIX> \ # e.g., hvac/carrier
+  --ha-mqtt-username <HA_MQTT_USERNAME> \         # Home Assistant MQTT username
+  --ha-mqtt-password <HA_MQTT_PASSWORD> \         # Home Assistant MQTT password
   --client-id <THERMOSTAT_DEVICE_ID>              # Your Thermostat Serial ID
 ```
 

--- a/cmd/anantha/cmd/serve.go
+++ b/cmd/anantha/cmd/serve.go
@@ -335,6 +335,8 @@ func init() {
 	serveCmd.Flags().String("ntp-addr", "", "NTP IPv4 Address (if unset, we won't respond to DNS requests for *.ntp.org)")
 	serveCmd.Flags().String("ha-mqtt-addr", "", "Home Assistant MQTT Host")
 	serveCmd.Flags().String("ha-mqtt-topic-prefix", "", "Home Assistant MQTT Topic Prefix")
+	serveCmd.Flags().String("ha-mqtt-username", "", "Home Assistant MQTT Username")
+	serveCmd.Flags().String("ha-mqtt-password", "", "Home Assistant MQTT Password")
 	serveCmd.Flags().String("reqs-dir", "$HOME/.anantha/protos", "Directory where request protos are stored")
 	serveCmd.Flags().String("client-id", "", "MQTT Client ID (this should be the same as the HVAC device ID, e.g. '4123X123456')")
 	serveCmd.Flags().String("thing-name-override", "", "Thingname override - you should never need to set this")
@@ -345,6 +347,8 @@ func runServe(cmd *cobra.Command, args []string) error {
 	ntpAddrStr, _ := cmd.Flags().GetString("ntp-addr")
 	haMQTTAddr, _ := cmd.Flags().GetString("ha-mqtt-addr")
 	haMQTTTopicPrefix, _ := cmd.Flags().GetString("ha-mqtt-topic-prefix")
+	haMQTTUsername, _ := cmd.Flags().GetString("ha-mqtt-username")
+	haMQTTPassword, _ := cmd.Flags().GetString("ha-mqtt-password")
 	protosDir, _ := cmd.Flags().GetString("reqs-dir")
 	clientID, _ := cmd.Flags().GetString("client-id")
 	thingNameOverride, _ := cmd.Flags().GetString("thing-name-override")
@@ -931,7 +935,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		})
 	})
 
-	haMQTT := NewHAMQTT(haMQTTAddr, haMQTTTopicPrefix, loadedValues, publishProto)
+	haMQTT := NewHAMQTT(haMQTTAddr, haMQTTTopicPrefix, haMQTTUsername, haMQTTPassword, clientID, loadedValues, publishProto)
 	go haMQTT.Run()
 
 	go func() {


### PR DESCRIPTION
I don't know Go that well, so please forgive me if there is a better way to do this.

I've added two optional flags to the `serve` command. If both of these are set, then the username/password combo is set in the MQTT client options before connecting to Home Assistant.
- `ha-mqtt-username` - The username to be used when connecting to Home Assistant's MQTT.
- `ha-mqtt-password` - The password to be used when connecting to Home Assistant's MQTT.

I've also passed the value of the `client-id` flag along to the MQTT client for Home Assistant, in order to add it as the value to the `unique_id` json key in the discovery message. This allows editing the entity in Home Assistant so you can set the display name, area, entity_id, etc.