### PR TITLE
Allow specification of external IP

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -35,8 +35,8 @@ docker run -p 53:53/udp -p 53:53/tcp -p 80:80 -p 443:443 -p 8883:8883 -p 26268:2
   --ha-mqtt-topic-prefix <HA_MQTT_TOPIC_PREFIX> \
   --ha-mqtt-username <HA_MQTT_USERNAME> \
   --ha-mqtt-password <HA_MQTT_PASSWORD> \
-  --client-id <THERMOSTAT_DEVICE_ID>
-  --external-ip <DOCKER_HOST_IP>
+  --client-id <THERMOSTAT_DEVICE_ID> \
+  --external-ip-override <DOCKER_HOST_IP> # Optional
 ```
 
 ### Docker Compose Example
@@ -60,7 +60,7 @@ services:
       --ha-mqtt-username HA_MQTT_USERNAME
       --ha-mqtt-password HA_MQTT_PASSWORD
       --client-id YOUR_THERMOSTAT_ID
-      --external-ip DOCKER_HOST_IP
+      --external-ip-override DOCKER_HOST_IP
     restart: unless-stopped
 ```
 

--- a/cmd/anantha/cmd/serve.go
+++ b/cmd/anantha/cmd/serve.go
@@ -179,9 +179,9 @@ func (m *MQTTLogger) OnPacketRead(cl *mqtt.Client, pk packets.Packet) (packets.P
 	return pk, nil
 }
 
-func GetExternalIP(externalIPString string) (net.IP, error) {
-	if externalIPString != "" {
-		var parsedIP net.IP = net.ParseIP(externalIPString)
+func GetExternalIP(externalIPOverride string) (net.IP, error) {
+	if externalIPOverride != "" {
+		var parsedIP net.IP = net.ParseIP(externalIPOverride)
 		if parsedIP != nil {
 			return parsedIP, nil
 		} else {
@@ -1610,7 +1610,7 @@ func init() {
 	serveCmd.Flags().String("ha-mqtt-password", "", "Home Assistant MQTT Password")
 	serveCmd.Flags().String("reqs-dir", "$HOME/.anantha/protos", "Directory where request protos are stored")
 	serveCmd.Flags().String("client-id", "", "MQTT Client ID (this should be the same as the HVAC device ID, e.g. '4123X123456')")
-	serveCmd.Flags().String("external-ip", "", "Override auto-detected external IP")
+	serveCmd.Flags().String("external-ip-override", "", "Override auto-detected external IP")
 	serveCmd.Flags().String("thing-name-override", "", "Thingname override - you should never need to set this")
 	serveCmd.Flags().Bool("proxy", false, "Proxy requests to AWS IOT - requires a valid client certificate for now (strongly discouraged)")
 }
@@ -1623,7 +1623,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 	haMQTTPassword, _ := cmd.Flags().GetString("ha-mqtt-password")
 	protosDir, _ := cmd.Flags().GetString("reqs-dir")
 	clientID, _ := cmd.Flags().GetString("client-id")
-	externalIPString, _ := cmd.Flags().GetString("external-ip")
+	externalIPOverride, _ := cmd.Flags().GetString("external-ip-override")
 	thingNameOverride, _ := cmd.Flags().GetString("thing-name-override")
 	proxyToAWSIOT, _ := cmd.Flags().GetBool("proxy")
 
@@ -1658,7 +1658,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		_, _ = io.Copy(os.Stderr, r.Body)
 	})
 
-	externalIP, err := GetExternalIP(externalIPString)
+	externalIP, err := GetExternalIP(externalIPOverride)
 	if err != nil {
 		return fmt.Errorf("failed to get external IP: %w", err)
 	}


### PR DESCRIPTION
Should resolve #11 

Firewall logs after change 
<img width="2785" height="304" alt="image" src="https://github.com/user-attachments/assets/590b3270-bbb8-4198-95ac-1ba3af27d08c" />


Docker logs showing communication from thermostat
```anantha  | 2025-12-02T03:26:24.652198663Z 03:26:24.651650 serve.go:1839: Done loading all proto messages
anantha  | 2025-12-02T03:26:24.652700124Z time=2025-12-02T03:26:24.652Z level=INFO msg="added hook" hook=logger
anantha  | 2025-12-02T03:26:24.653221884Z time=2025-12-02T03:26:24.653Z level=INFO msg="attached listener" id=t1 protocol=tcp address=[::]:8883
anantha  | 2025-12-02T03:26:24.653315633Z time=2025-12-02T03:26:24.653Z level=INFO msg="added hook" hook=allow-all-auth
anantha  | 2025-12-02T03:26:24.653356818Z time=2025-12-02T03:26:24.653Z level=INFO msg="mochi mqtt starting" version=2.7.9
anantha  | 2025-12-02T03:26:24.654548916Z time=2025-12-02T03:26:24.654Z level=INFO msg="mochi mqtt server started"
anantha  | 2025-12-02T03:26:24.654813642Z 03:26:24.654573 serve.go:2443: Got weather request [entries:{name:"postal" config_type:CT_STRING maybe_str_value:"20136"} detail_type_str:"weather_req" 1:""]
anantha  | 2025-12-02T03:26:25.388683893Z 03:26:25.388465 serve.go:2589: Listening for interrupt signals
anantha  | 2025-12-02T03:26:25.388828086Z 03:26:25.388504 hamqtt.go:356: Connecting to mqtt:1883
anantha  | 2025-12-02T03:26:25.390946403Z 03:26:25.390826 hamqtt.go:360: Connected to mqtt:1883
anantha  | 2025-12-02T03:26:25.390977241Z 03:26:25.390868 hamqtt.go:347: MQTT connection established to mqtt:1883
anantha  | 2025-12-02T03:26:38.611581675Z 03:26:38.611365 serve.go:1683: MQTT Req from 192.168.253.100:32982: mqtt.res.carrier.io.
anantha  | 2025-12-02T03:26:38.869122328Z 03:26:38.868978 serve.go:2305: GetCertificate for mqtt.res.carrier.io
anantha  | 2025-12-02T03:26:40.170937857Z 03:26:40.170500 serve.go:133: SUBSCRIBE from 2025W205449: map[spBv1.0/WallCtrl/NCMD/2025W205449:1]
anantha  | 2025-12-02T03:26:41.221736881Z 03:26:41.221549 serve.go:133: SUBSCRIBE from 2025W205449: map[spBv1.0/WallCtrl/DCMD/2025W205449/energy_star:1]
anantha  | 2025-12-02T03:26:42.236012437Z 03:26:42.235772 serve.go:133: SUBSCRIBE from 2025W205449: map[spBv1.0/WallCtrl/DCMD/2025W205449/idu:1]
anantha  | 2025-12-02T03:26:43.261808591Z 03:26:43.261478 serve.go:133: SUBSCRIBE from 2025W205449: map[spBv1.0/WallCtrl/DCMD/2025W205449/odu:1]
anantha  | 2025-12-02T03:26:44.302619900Z 03:26:44.302376 serve.go:133: SUBSCRIBE from 2025W205449: map[spBv1.0/WallCtrl/DCMD/2025W205449/zones:1]
anantha  | 2025-12-02T03:26:45.310810512Z 03:26:45.310587 serve.go:133: SUBSCRIBE from 2025W205449: map[spBv1.0/WallCtrl/DCMD/2025W205449/debug:1]
anantha  | 2025-12-02T03:26:46.334930735Z 03:26:46.334665 serve.go:133: SUBSCRIBE from 2025W205449: map[spBv1.0/WallCtrl/DCMD/2025W205449/energy:1]
anantha  | 2025-12-02T03:26:52.010527039Z 03:26:52.010319 serve.go:98: PUBLISH from 2025W205449: spBv1.0/WallCtrl/NDATA/2025W205449 [len: 1728]
anantha  | 2025-12-02T03:26:52.018239718Z 03:26:52.017861 serve.go:2443: Got weather request [entries:{name:"postal" config_type:CT_STRING maybe_str_value:"<REDACTED>"} detail_type_str:"weather_req" 1:""]
anantha  | 2025-12-02T03:26:52.021252909Z 03:26:52.021120 types.go:353: Removed unreferenced proto file: spBv1.0_WallCtrl_NDATA_2025W205449-2025-12-02T03:19:28.58907743Z.pb
anantha  | 2025-12-02T03:26:52.022794415Z 03:26:52.022686 types.go:353: Removed unreferenced proto file: spBv1.0_WallCtrl_NDATA_2025W205449-2025-12-02T03:18:27.897115292Z.pb
anantha  | 2025-12-02T03:27:29.724063200Z 03:27:29.723800 serve.go:98: PUBLISH from 2025W205449: spBv1.0/WallCtrl/NDATA/2025W205449 [len: 75]
anantha  | 2025-12-02T03:27:38.175086948Z 03:27:38.174736 serve.go:98: PUBLISH from 2025W205449: spBv1.0/WallCtrl/DDATA/2025W205449/energy [len: 26]
anantha  | 2025-12-02T03:27:38.267706881Z 03:27:38.267473 types.go:353: Removed unreferenced proto file: spBv1.0_WallCtrl_DDATA_2025W205449_energy-2025-12-02T03:26:04.348426497Z.pb
```

Quite rusty on golang, so there's a big chance I didn't do this optimally