### PR TITLE
Add a refresh-state button to the dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Set your thermostat's DNS Server to Anantha's IP address.
 - HTTP server (ports 80, 443) for firmware updates and requests
 - Web dashboard (port 26268 - spells "ANANT" on a phone keypad) for debugging
 - Home Assistant integration with auto-discovery for controlling the thermostat
+- Automatic full-state synchronization on (re)connect via a Sparkplug B `Node Control/Rebirth` command
 - Optional MQTT proxying to AWS IoT (requires additional setup)
 
 ## Debugging
@@ -86,6 +87,7 @@ Known working devices and firmware versions:
 | Carrier | SYSTXCCITC01-B | v4.47 |
 | Carrier | SYSTXCCITC01-B | v4.56 |
 | Carrier | SYSTXCCITC01-B | v4.74 |
+| Carrier | SYSTXCCITC01-C | v2.00 |
 
 ## Technical Details
 
@@ -94,3 +96,11 @@ Since firmware v4.17, Carrier thermostats use AWS IoT for MQTT communication. Un
 For sparse details about the certificate generation process, see the `cmd/cagen` directory.
 
 For a barebones proto definition of the communication over MQTT, see protobuf definitions in the `proto` directory.
+
+### State synchronization
+
+The thermostat speaks a Sparkplug B-shaped protocol over MQTT and publishes deltas, not full snapshots, after its initial connect. Without intervention, a freshly-started Anantha (no on-disk proto cache) would render an empty `/schedule` and mostly-empty `/profiles` until the user manually edited every field on the thermostat. Wifi cycling on the thermostat does not help.
+
+Anantha works around this by sending a `Node Control/Rebirth = true` (CT_BOOL) command to `spBv1.0/WallCtrl/NCMD/<clientID>` 120 seconds after the first qualifying PUBLISH from the thermostat. The firmware honors this rebirth request and republishes its full state (~2200 entries: schedule, activity setpoints, sensor templates, system info), producing a fully-populated dashboard within roughly 3.5 minutes of a cold start. The 120-second delay is necessary because the firmware silently drops rebirth requests received during its own NBIRTH announcement window.
+
+The rebirth fires once per session and is reset on every CONNECT, so reconnects re-trigger it. Mid-session firings are safe no-ops if state is already in sync.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Set your thermostat's DNS Server to Anantha's IP address.
 - HTTP server (ports 80, 443) for firmware updates and requests
 - Web dashboard (port 26268 - spells "ANANT" on a phone keypad) for debugging
 - Home Assistant integration with auto-discovery for controlling the thermostat
-- Automatic full-state synchronization on (re)connect via a Sparkplug B `Node Control/Rebirth` command
+- User-initiated full-state refresh button on the dashboard, which sends a Sparkplug B `Node Control/Rebirth` command to the thermostat
 - Optional MQTT proxying to AWS IoT (requires additional setup)
 
 ## Debugging
@@ -101,6 +101,10 @@ For a barebones proto definition of the communication over MQTT, see protobuf de
 
 The thermostat speaks a Sparkplug B-shaped protocol over MQTT and publishes deltas, not full snapshots, after its initial connect. Without intervention, a freshly-started Anantha (no on-disk proto cache) would render an empty `/schedule` and mostly-empty `/profiles` until the user manually edited every field on the thermostat. Wifi cycling on the thermostat does not help.
 
-Anantha works around this by sending a `Node Control/Rebirth = true` (CT_BOOL) command to `spBv1.0/WallCtrl/NCMD/<clientID>` 120 seconds after the first qualifying PUBLISH from the thermostat. The firmware honors this rebirth request and republishes its full state (~2200 entries: schedule, activity setpoints, sensor templates, system info), producing a fully-populated dashboard within roughly 3.5 minutes of a cold start. The 120-second delay is necessary because the firmware silently drops rebirth requests received during its own NBIRTH announcement window.
+The dashboard exposes a "Refresh thermostat state" button that sends a `Node Control/Rebirth = true` (CT_BOOL) command to `spBv1.0/WallCtrl/NCMD/<clientID>`. The firmware honors this rebirth request and republishes its full state (~2200 entries: schedule, activity setpoints, sensor templates, system info), populating the dashboard within roughly a minute. The button's pre-text changes based on a per-page-load completeness check so the user can see whether a refresh is likely useful, but it remains clickable in either case.
 
-The rebirth fires once per session and is reset on every CONNECT, so reconnects re-trigger it. Mid-session firings are safe no-ops if state is already in sync.
+A few protections keep the firmware from being hammered:
+
+- Server-side cooldown of 90 seconds between successful sends (the response itself takes ~60 seconds to drain, so this leaves comfortable headroom).
+- If the click arrives during the firmware's NBIRTH announcement window (the first 120 seconds after CONNECT, during which it silently drops rebirth requests), the click is queued and a one-shot timer fires the rebirth as soon as the window clears.
+- If the thermostat has not yet published anything to Anantha, the click short-circuits with a clear message instead of sending into the void.

--- a/TODO.md
+++ b/TODO.md
@@ -17,6 +17,12 @@
 - [x] Better proto cleanup. We dump protobufs sent by thermostat in a directory which gets garbage collected on process startup.
   Do this on a schedule or as required.
 - [x] Weather integration with Open Meteo? Currently, we pretend to be in a California summer all year round.
+- [x] Automatic full-state recovery on (re)connect. The thermostat only publishes deltas after CONNECT, so a fresh anantha
+  install (or one with an empty proto cache) used to render an empty schedule and profiles until the user manually edited
+  every field on the thermostat. Anantha now sends a Sparkplug B "Node Control/Rebirth" command 120s after the first
+  qualifying PUBLISH, which causes the firmware to dump its full state (~2200 entries) and produces a complete dashboard
+  within ~3.5 minutes of cold start. The 120s delay is necessary because the firmware silently drops rebirth requests
+  received during its own NBIRTH window.
 - [ ] Perform firmware patching via auto-update mechanism within the thermostat. Could be a way to onboard without needing an SD-card to flash firmware.
   Kind of dangerous given how some bits in the thermostat cannot be overwritten once set (like AWS IOT thingname, certs etc?). Could cause
   the thermostat to potentially get "bricked" if you want to use AWS IOT/Carrier API again.

--- a/TODO.md
+++ b/TODO.md
@@ -17,12 +17,13 @@
 - [x] Better proto cleanup. We dump protobufs sent by thermostat in a directory which gets garbage collected on process startup.
   Do this on a schedule or as required.
 - [x] Weather integration with Open Meteo? Currently, we pretend to be in a California summer all year round.
-- [x] Automatic full-state recovery on (re)connect. The thermostat only publishes deltas after CONNECT, so a fresh anantha
+- [x] Full-state recovery via dashboard button. The thermostat only publishes deltas after CONNECT, so a fresh anantha
   install (or one with an empty proto cache) used to render an empty schedule and profiles until the user manually edited
-  every field on the thermostat. Anantha now sends a Sparkplug B "Node Control/Rebirth" command 120s after the first
-  qualifying PUBLISH, which causes the firmware to dump its full state (~2200 entries) and produces a complete dashboard
-  within ~3.5 minutes of cold start. The 120s delay is necessary because the firmware silently drops rebirth requests
-  received during its own NBIRTH window.
+  every field on the thermostat. The dashboard now exposes a "Refresh thermostat state" button that sends a Sparkplug B
+  "Node Control/Rebirth" command, causing the firmware to dump its full state (~2200 entries) and producing a complete
+  dashboard within ~60 seconds of the click. A 90-second server-side cooldown prevents firmware spam, and clicks during
+  the firmware's 120-second NBIRTH window (when rebirth requests are silently dropped) are queued and fired automatically
+  once the window clears.
 - [ ] Perform firmware patching via auto-update mechanism within the thermostat. Could be a way to onboard without needing an SD-card to flash firmware.
   Kind of dangerous given how some bits in the thermostat cannot be overwritten once set (like AWS IOT thingname, certs etc?). Could cause
   the thermostat to potentially get "bricked" if you want to use AWS IOT/Carrier API again.

--- a/cmd/anantha/cmd/serve.go
+++ b/cmd/anantha/cmd/serve.go
@@ -63,6 +63,7 @@ type MQTTLogger struct {
 	liveClients map[string]struct{}
 
 	rebirthCancels map[string]context.CancelFunc
+	rebirthFired   map[string]struct{}
 	rebirthLock    sync.Mutex
 	rebirthDelay   time.Duration
 }
@@ -98,12 +99,18 @@ func (m *MQTTLogger) sendRebirth() {
 
 // scheduleRebirth arranges for sendRebirth to fire after rebirthDelay. The
 // firmware silently drops rebirth requests received during its own NBIRTH
-// window (~T+30s after CONNECT); 120s clears that with margin. Idempotent per
-// client: subsequent calls during the wait are no-ops. Cancellable on CONNECT
-// via the stored cancel func.
+// window (~T+30s after CONNECT); 120s clears that with margin. The gate is
+// sticky for the session: once fired, subsequent qualifying PUBLISHes (notably
+// the firmware's NBIRTH response to our rebirth, which would otherwise re-
+// trigger us in a loop) are no-ops until CONNECT clears the state.
+// Cancellable mid-wait via the stored cancel func.
 func (m *MQTTLogger) scheduleRebirth(clientID string) {
 	m.rebirthLock.Lock()
-	if _, exists := m.rebirthCancels[clientID]; exists {
+	if _, fired := m.rebirthFired[clientID]; fired {
+		m.rebirthLock.Unlock()
+		return
+	}
+	if _, scheduled := m.rebirthCancels[clientID]; scheduled {
 		m.rebirthLock.Unlock()
 		return
 	}
@@ -121,11 +128,14 @@ func (m *MQTTLogger) scheduleRebirth(clientID string) {
 		case <-time.After(m.rebirthDelay):
 		}
 
-		// Remove ourselves from the map BEFORE publishing so a CONNECT racing
-		// with us doesn't try to cancel an already-completed timer. Calling
-		// cancel() on an already-completed context is harmless either way.
+		// Mark fired and remove from the cancel map atomically before publishing,
+		// so any qualifying PUBLISH that arrives in response to the rebirth (e.g.
+		// the firmware's NBIRTH) sees rebirthFired[clientID] and skips re-scheduling.
+		// Calling cancel() on an already-completed context is harmless, so a CONNECT
+		// racing with us cannot misfire.
 		m.rebirthLock.Lock()
 		delete(m.rebirthCancels, clientID)
+		m.rebirthFired[clientID] = struct{}{}
 		m.rebirthLock.Unlock()
 
 		m.sendRebirth()
@@ -240,8 +250,8 @@ func (m *MQTTLogger) OnPacketRead(cl *mqtt.Client, pk packets.Packet) (packets.P
 	case packets.Connect:
 		// Empty liveClients list on CONNECT. Make sure we get a PUBLISH spBv1.0/WallCtrl/NDATA/<thingName> before polling
 		m.liveClients = map[string]struct{}{}
-		// Cancel any in-flight rebirth timers from a prior session, then reset
-		// the map so the next qualifying PUBLISH re-schedules. CONNECT is the
+		// Cancel any in-flight rebirth timers from a prior session and clear the
+		// fired set so the next qualifying PUBLISH re-schedules. CONNECT is the
 		// canonical "new session" signal - more reliable than DISCONNECT, which
 		// won't fire on abrupt drops (power loss, wifi flap with no clean LWT).
 		m.rebirthLock.Lock()
@@ -249,6 +259,7 @@ func (m *MQTTLogger) OnPacketRead(cl *mqtt.Client, pk packets.Packet) (packets.P
 			cancel()
 		}
 		m.rebirthCancels = map[string]context.CancelFunc{}
+		m.rebirthFired = map[string]struct{}{}
 		m.rebirthLock.Unlock()
 	case packets.Pingreq:
 		// Don't log PINGREQ
@@ -1135,6 +1146,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		loadedValues:      loadedValues,
 		liveClients:       make(map[string]struct{}),
 		rebirthCancels:    make(map[string]context.CancelFunc),
+		rebirthFired:      make(map[string]struct{}),
 		rebirthDelay:      120 * time.Second,
 	}
 

--- a/cmd/anantha/cmd/serve.go
+++ b/cmd/anantha/cmd/serve.go
@@ -801,7 +801,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		webControlMux.Handle("/metrics", MetricsHandler(loadedValues))
 		webControlMux.Handle("/assets/", http.FileServer(http.FS(assets)))
 		webControlMux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-			indexHTML, err := RenderIndex()
+			indexHTML, err := RenderIndex(loadedValues)
 			if err != nil {
 				http.Error(w, fmt.Sprintf("Error rendering index: %v", err), http.StatusInternalServerError)
 				return

--- a/cmd/anantha/cmd/serve.go
+++ b/cmd/anantha/cmd/serve.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"crypto/tls"
 	"embed"
 	"errors"
@@ -61,8 +62,9 @@ type MQTTLogger struct {
 
 	liveClients map[string]struct{}
 
-	rebirthSent     map[string]struct{}
-	rebirthSentLock sync.Mutex
+	rebirthCancels map[string]context.CancelFunc
+	rebirthLock    sync.Mutex
+	rebirthDelay   time.Duration
 }
 
 // sendRebirth publishes a Sparkplug B "Node Control/Rebirth" = true command on
@@ -92,6 +94,42 @@ func (m *MQTTLogger) sendRebirth() {
 		return
 	}
 	log.Printf("Sent Node Control/Rebirth to %s", m.cmdTopic)
+}
+
+// scheduleRebirth arranges for sendRebirth to fire after rebirthDelay. The
+// firmware silently drops rebirth requests received during its own NBIRTH
+// window (~T+30s after CONNECT); 120s clears that with margin. Idempotent per
+// client: subsequent calls during the wait are no-ops. Cancellable on CONNECT
+// via the stored cancel func.
+func (m *MQTTLogger) scheduleRebirth(clientID string) {
+	m.rebirthLock.Lock()
+	if _, exists := m.rebirthCancels[clientID]; exists {
+		m.rebirthLock.Unlock()
+		return
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	m.rebirthCancels[clientID] = cancel
+	m.rebirthLock.Unlock()
+
+	log.Printf("Scheduled Node Control/Rebirth in %s for %s", m.rebirthDelay, clientID)
+
+	go func() {
+		select {
+		case <-ctx.Done():
+			log.Printf("Cancelled scheduled rebirth for %s", clientID)
+			return
+		case <-time.After(m.rebirthDelay):
+		}
+
+		// Remove ourselves from the map BEFORE publishing so a CONNECT racing
+		// with us doesn't try to cancel an already-completed timer. Calling
+		// cancel() on an already-completed context is harmless either way.
+		m.rebirthLock.Lock()
+		delete(m.rebirthCancels, clientID)
+		m.rebirthLock.Unlock()
+
+		m.sendRebirth()
+	}()
 }
 
 // ID returns the ID of the hook.
@@ -129,16 +167,7 @@ func (m *MQTTLogger) OnPacketRead(cl *mqtt.Client, pk packets.Packet) (packets.P
 			(m.thingNameOverride == "" && strings.HasSuffix(pk.TopicName, m.clientID)) {
 			// Client sent initial PUBLISH - ready to poll it
 			m.liveClients[cl.ID] = struct{}{}
-
-			m.rebirthSentLock.Lock()
-			_, alreadySent := m.rebirthSent[cl.ID]
-			if !alreadySent {
-				m.rebirthSent[cl.ID] = struct{}{}
-			}
-			m.rebirthSentLock.Unlock()
-			if !alreadySent {
-				m.sendRebirth()
-			}
+			m.scheduleRebirth(cl.ID)
 		}
 		protoFilename := fmt.Sprintf("%s-%s.pb", strings.ReplaceAll(string(pk.TopicName), "/", "_"), time.Now().Format(time.RFC3339Nano))
 		if err := os.WriteFile(
@@ -211,13 +240,16 @@ func (m *MQTTLogger) OnPacketRead(cl *mqtt.Client, pk packets.Packet) (packets.P
 	case packets.Connect:
 		// Empty liveClients list on CONNECT. Make sure we get a PUBLISH spBv1.0/WallCtrl/NDATA/<thingName> before polling
 		m.liveClients = map[string]struct{}{}
-		// Reset the rebirth-sent gate so the next qualifying PUBLISH triggers a
-		// fresh rebirth for this new session. CONNECT is the canonical "new
-		// session" signal — more reliable than DISCONNECT, which won't fire on
-		// abrupt drops (power loss, wifi flap with no clean LWT).
-		m.rebirthSentLock.Lock()
-		m.rebirthSent = map[string]struct{}{}
-		m.rebirthSentLock.Unlock()
+		// Cancel any in-flight rebirth timers from a prior session, then reset
+		// the map so the next qualifying PUBLISH re-schedules. CONNECT is the
+		// canonical "new session" signal - more reliable than DISCONNECT, which
+		// won't fire on abrupt drops (power loss, wifi flap with no clean LWT).
+		m.rebirthLock.Lock()
+		for _, cancel := range m.rebirthCancels {
+			cancel()
+		}
+		m.rebirthCancels = map[string]context.CancelFunc{}
+		m.rebirthLock.Unlock()
 	case packets.Pingreq:
 		// Don't log PINGREQ
 	default:
@@ -1102,7 +1134,8 @@ func runServe(cmd *cobra.Command, args []string) error {
 		subscribedTopics:  make(map[string]struct{}),
 		loadedValues:      loadedValues,
 		liveClients:       make(map[string]struct{}),
-		rebirthSent:       make(map[string]struct{}),
+		rebirthCancels:    make(map[string]context.CancelFunc),
+		rebirthDelay:      120 * time.Second,
 	}
 
 	if err := server.AddHook(mLogger, nil); err != nil {

--- a/cmd/anantha/cmd/serve.go
+++ b/cmd/anantha/cmd/serve.go
@@ -50,6 +50,7 @@ type MQTTLogger struct {
 	iotMQTTClient     mqtt_paho.Client
 	clientID          string
 	thingNameOverride string
+	cmdTopic          string
 
 	subscribedTopics     map[string]struct{}
 	subscribedTopicsLock sync.Mutex
@@ -59,6 +60,38 @@ type MQTTLogger struct {
 	loadedValues *LoadedValues
 
 	liveClients map[string]struct{}
+
+	rebirthSent     map[string]struct{}
+	rebirthSentLock sync.Mutex
+}
+
+// sendRebirth publishes a Sparkplug B "Node Control/Rebirth" = true command on
+// the NCMD topic. The Carrier firmware honors this: it dumps full state
+// (schedule, activity setpoints, ~2200 entries) within ~17 seconds.
+func (m *MQTTLogger) sendRebirth() {
+	msg := &carrier.CarrierInfo{
+		TimestampMillis: time.Now().UnixMilli(),
+		ConfigSettings: []*carrier.ConfigSetting{
+			{
+				Name:       "Node Control/Rebirth",
+				ConfigType: carrier.ConfigType_CT_BOOL,
+				Value: &carrier.ConfigSetting_BoolValue{
+					BoolValue: true,
+				},
+			},
+		},
+		Uuid: uuid.New().String(),
+	}
+	encoded, err := proto.Marshal(msg)
+	if err != nil {
+		log.Printf("Failed to encode rebirth proto: %s", err)
+		return
+	}
+	if err := m.server.Publish(m.cmdTopic, encoded, false, 0); err != nil {
+		log.Printf("Failed to send rebirth: %s", err)
+		return
+	}
+	log.Printf("Sent Node Control/Rebirth to %s", m.cmdTopic)
 }
 
 // ID returns the ID of the hook.
@@ -96,6 +129,16 @@ func (m *MQTTLogger) OnPacketRead(cl *mqtt.Client, pk packets.Packet) (packets.P
 			(m.thingNameOverride == "" && strings.HasSuffix(pk.TopicName, m.clientID)) {
 			// Client sent initial PUBLISH - ready to poll it
 			m.liveClients[cl.ID] = struct{}{}
+
+			m.rebirthSentLock.Lock()
+			_, alreadySent := m.rebirthSent[cl.ID]
+			if !alreadySent {
+				m.rebirthSent[cl.ID] = struct{}{}
+			}
+			m.rebirthSentLock.Unlock()
+			if !alreadySent {
+				m.sendRebirth()
+			}
 		}
 		protoFilename := fmt.Sprintf("%s-%s.pb", strings.ReplaceAll(string(pk.TopicName), "/", "_"), time.Now().Format(time.RFC3339Nano))
 		if err := os.WriteFile(
@@ -168,6 +211,13 @@ func (m *MQTTLogger) OnPacketRead(cl *mqtt.Client, pk packets.Packet) (packets.P
 	case packets.Connect:
 		// Empty liveClients list on CONNECT. Make sure we get a PUBLISH spBv1.0/WallCtrl/NDATA/<thingName> before polling
 		m.liveClients = map[string]struct{}{}
+		// Reset the rebirth-sent gate so the next qualifying PUBLISH triggers a
+		// fresh rebirth for this new session. CONNECT is the canonical "new
+		// session" signal — more reliable than DISCONNECT, which won't fire on
+		// abrupt drops (power loss, wifi flap with no clean LWT).
+		m.rebirthSentLock.Lock()
+		m.rebirthSent = map[string]struct{}{}
+		m.rebirthSentLock.Unlock()
 	case packets.Pingreq:
 		// Don't log PINGREQ
 	default:
@@ -1048,9 +1098,11 @@ func runServe(cmd *cobra.Command, args []string) error {
 		iotMQTTClient:     awsIOTMQTTClient,
 		clientID:          clientID,
 		thingNameOverride: thingNameOverride,
+		cmdTopic:          cmdTopic,
 		subscribedTopics:  make(map[string]struct{}),
 		loadedValues:      loadedValues,
 		liveClients:       make(map[string]struct{}),
+		rebirthSent:       make(map[string]struct{}),
 	}
 
 	if err := server.AddHook(mLogger, nil); err != nil {

--- a/cmd/anantha/cmd/serve.go
+++ b/cmd/anantha/cmd/serve.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"crypto/tls"
 	"embed"
 	"errors"
@@ -61,16 +60,15 @@ type MQTTLogger struct {
 	loadedValues *LoadedValues
 
 	liveClients map[string]struct{}
-
-	rebirthCancels map[string]context.CancelFunc
-	rebirthFired   map[string]struct{}
-	rebirthLock    sync.Mutex
-	rebirthDelay   time.Duration
 }
 
 // sendRebirth publishes a Sparkplug B "Node Control/Rebirth" = true command on
-// the NCMD topic. The Carrier firmware honors this: it dumps full state
-// (schedule, activity setpoints, ~2200 entries) within ~17 seconds.
+// the NCMD topic. The Carrier firmware honors this and replies with a full
+// NBIRTH/DBIRTH wave (~99 KB across 7 publishes over ~60 seconds), which
+// repopulates schedule, activity setpoints, and other config from the
+// thermostat.
+//
+//nolint:unused // wired up by the /refresh-state handler in a follow-up commit
 func (m *MQTTLogger) sendRebirth() {
 	msg := &carrier.CarrierInfo{
 		TimestampMillis: time.Now().UnixMilli(),
@@ -95,51 +93,6 @@ func (m *MQTTLogger) sendRebirth() {
 		return
 	}
 	log.Printf("Sent Node Control/Rebirth to %s", m.cmdTopic)
-}
-
-// scheduleRebirth arranges for sendRebirth to fire after rebirthDelay. The
-// firmware silently drops rebirth requests received during its own NBIRTH
-// window (~T+30s after CONNECT); 120s clears that with margin. The gate is
-// sticky for the session: once fired, subsequent qualifying PUBLISHes (notably
-// the firmware's NBIRTH response to our rebirth, which would otherwise re-
-// trigger us in a loop) are no-ops until CONNECT clears the state.
-// Cancellable mid-wait via the stored cancel func.
-func (m *MQTTLogger) scheduleRebirth(clientID string) {
-	m.rebirthLock.Lock()
-	if _, fired := m.rebirthFired[clientID]; fired {
-		m.rebirthLock.Unlock()
-		return
-	}
-	if _, scheduled := m.rebirthCancels[clientID]; scheduled {
-		m.rebirthLock.Unlock()
-		return
-	}
-	ctx, cancel := context.WithCancel(context.Background())
-	m.rebirthCancels[clientID] = cancel
-	m.rebirthLock.Unlock()
-
-	log.Printf("Scheduled Node Control/Rebirth in %s for %s", m.rebirthDelay, clientID)
-
-	go func() {
-		select {
-		case <-ctx.Done():
-			log.Printf("Cancelled scheduled rebirth for %s", clientID)
-			return
-		case <-time.After(m.rebirthDelay):
-		}
-
-		// Mark fired and remove from the cancel map atomically before publishing,
-		// so any qualifying PUBLISH that arrives in response to the rebirth (e.g.
-		// the firmware's NBIRTH) sees rebirthFired[clientID] and skips re-scheduling.
-		// Calling cancel() on an already-completed context is harmless, so a CONNECT
-		// racing with us cannot misfire.
-		m.rebirthLock.Lock()
-		delete(m.rebirthCancels, clientID)
-		m.rebirthFired[clientID] = struct{}{}
-		m.rebirthLock.Unlock()
-
-		m.sendRebirth()
-	}()
 }
 
 // ID returns the ID of the hook.
@@ -177,7 +130,6 @@ func (m *MQTTLogger) OnPacketRead(cl *mqtt.Client, pk packets.Packet) (packets.P
 			(m.thingNameOverride == "" && strings.HasSuffix(pk.TopicName, m.clientID)) {
 			// Client sent initial PUBLISH - ready to poll it
 			m.liveClients[cl.ID] = struct{}{}
-			m.scheduleRebirth(cl.ID)
 		}
 		protoFilename := fmt.Sprintf("%s-%s.pb", strings.ReplaceAll(string(pk.TopicName), "/", "_"), time.Now().Format(time.RFC3339Nano))
 		if err := os.WriteFile(
@@ -250,17 +202,6 @@ func (m *MQTTLogger) OnPacketRead(cl *mqtt.Client, pk packets.Packet) (packets.P
 	case packets.Connect:
 		// Empty liveClients list on CONNECT. Make sure we get a PUBLISH spBv1.0/WallCtrl/NDATA/<thingName> before polling
 		m.liveClients = map[string]struct{}{}
-		// Cancel any in-flight rebirth timers from a prior session and clear the
-		// fired set so the next qualifying PUBLISH re-schedules. CONNECT is the
-		// canonical "new session" signal - more reliable than DISCONNECT, which
-		// won't fire on abrupt drops (power loss, wifi flap with no clean LWT).
-		m.rebirthLock.Lock()
-		for _, cancel := range m.rebirthCancels {
-			cancel()
-		}
-		m.rebirthCancels = map[string]context.CancelFunc{}
-		m.rebirthFired = map[string]struct{}{}
-		m.rebirthLock.Unlock()
 	case packets.Pingreq:
 		// Don't log PINGREQ
 	default:
@@ -1145,9 +1086,6 @@ func runServe(cmd *cobra.Command, args []string) error {
 		subscribedTopics:  make(map[string]struct{}),
 		loadedValues:      loadedValues,
 		liveClients:       make(map[string]struct{}),
-		rebirthCancels:    make(map[string]context.CancelFunc),
-		rebirthFired:      make(map[string]struct{}),
-		rebirthDelay:      120 * time.Second,
 	}
 
 	if err := server.AddHook(mLogger, nil); err != nil {

--- a/cmd/anantha/cmd/serve.go
+++ b/cmd/anantha/cmd/serve.go
@@ -60,6 +60,13 @@ type MQTTLogger struct {
 	loadedValues *LoadedValues
 
 	liveClients map[string]struct{}
+
+	// State for the user-initiated /refresh-state button. All four fields are
+	// guarded by refreshMu.
+	refreshMu                sync.Mutex
+	firstQualifyingPublishAt time.Time // zero when no qualifying PUBLISH seen this session
+	pendingRebirth           bool      // user clicked during the firmware NBIRTH window; fire when ready
+	rebirthLastSent          time.Time // last successful sendRebirth, for cooldown
 }
 
 // sendRebirth publishes a Sparkplug B "Node Control/Rebirth" = true command on
@@ -67,8 +74,6 @@ type MQTTLogger struct {
 // NBIRTH/DBIRTH wave (~99 KB across 7 publishes over ~60 seconds), which
 // repopulates schedule, activity setpoints, and other config from the
 // thermostat.
-//
-//nolint:unused // wired up by the /refresh-state handler in a follow-up commit
 func (m *MQTTLogger) sendRebirth() {
 	msg := &carrier.CarrierInfo{
 		TimestampMillis: time.Now().UnixMilli(),
@@ -130,6 +135,23 @@ func (m *MQTTLogger) OnPacketRead(cl *mqtt.Client, pk packets.Packet) (packets.P
 			(m.thingNameOverride == "" && strings.HasSuffix(pk.TopicName, m.clientID)) {
 			// Client sent initial PUBLISH - ready to poll it
 			m.liveClients[cl.ID] = struct{}{}
+
+			m.refreshMu.Lock()
+			if m.firstQualifyingPublishAt.IsZero() {
+				m.firstQualifyingPublishAt = time.Now()
+			}
+			// If a /refresh-state click queued a rebirth while we were still in
+			// the firmware's NBIRTH window, fire it now if enough time has passed.
+			shouldFirePending := m.pendingRebirth && time.Since(m.firstQualifyingPublishAt) >= 120*time.Second
+			if shouldFirePending {
+				m.pendingRebirth = false
+				m.rebirthLastSent = time.Now()
+			}
+			m.refreshMu.Unlock()
+			if shouldFirePending {
+				log.Printf("Firing queued Node Control/Rebirth (NBIRTH window cleared)")
+				m.sendRebirth()
+			}
 		}
 		protoFilename := fmt.Sprintf("%s-%s.pb", strings.ReplaceAll(string(pk.TopicName), "/", "_"), time.Now().Format(time.RFC3339Nano))
 		if err := os.WriteFile(
@@ -202,6 +224,17 @@ func (m *MQTTLogger) OnPacketRead(cl *mqtt.Client, pk packets.Packet) (packets.P
 	case packets.Connect:
 		// Empty liveClients list on CONNECT. Make sure we get a PUBLISH spBv1.0/WallCtrl/NDATA/<thingName> before polling
 		m.liveClients = map[string]struct{}{}
+
+		// New MQTT session - clear refresh-button state from the prior session.
+		// firstQualifyingPublishAt will be re-set on the next qualifying PUBLISH
+		// (the first NDATA on the thingname-suffixed topic). pendingRebirth was
+		// queued by a click against the old session, so it's no longer valid.
+		// rebirthLastSent intentionally survives the reconnect so the cooldown
+		// can't be bypassed by power-cycling the thermostat.
+		m.refreshMu.Lock()
+		m.firstQualifyingPublishAt = time.Time{}
+		m.pendingRebirth = false
+		m.refreshMu.Unlock()
 	case packets.Pingreq:
 		// Don't log PINGREQ
 	default:
@@ -478,6 +511,10 @@ func runServe(cmd *cobra.Command, args []string) error {
 		cmdTopic = fmt.Sprintf("spBv1.0/WallCtrl/NCMD/%s", thingNameOverride)
 	}
 
+	// Forward-declared so the web mux goroutine (which starts before mLogger
+	// is constructed below) can capture it for /refresh-state.
+	var mLogger *MQTTLogger
+
 	carrierHTTPMux := http.NewServeMux()
 
 	carrierHTTPMux.HandleFunc("/Alive", func(w http.ResponseWriter, r *http.Request) {
@@ -745,6 +782,61 @@ func runServe(cmd *cobra.Command, args []string) error {
 				return
 			}
 			fmt.Fprint(w, indexHTML)
+		})
+		webControlMux.HandleFunc("/refresh-state", func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost {
+				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+				return
+			}
+			if mLogger == nil {
+				// MQTT server hasn't finished initializing yet. Brief window at startup.
+				fmt.Fprint(w, `<span class="error">Anantha is still starting up. Please try again in a few seconds.</span>`)
+				return
+			}
+
+			// Subcase A: thermostat is not connected to anantha. The publish would
+			// land at the broker with no subscriber and silently disappear, so
+			// short-circuit with a clear message.
+			if len(mLogger.liveClients) == 0 {
+				fmt.Fprint(w, `<span>The thermostat is not connected to anantha yet. Please wait for it to publish before requesting a refresh.</span>`)
+				return
+			}
+
+			const cooldown = 90 * time.Second
+			const nbirthWindow = 120 * time.Second
+
+			mLogger.refreshMu.Lock()
+			now := time.Now()
+
+			// Cooldown check.
+			if !mLogger.rebirthLastSent.IsZero() {
+				if since := now.Sub(mLogger.rebirthLastSent); since < cooldown {
+					remaining := cooldown - since
+					mLogger.refreshMu.Unlock()
+					fmt.Fprintf(w, `<span>A refresh was sent recently. Please wait %d seconds before refreshing again.</span>`, int(remaining.Round(time.Second).Seconds()))
+					return
+				}
+			}
+
+			// Subcase B: thermostat is connected but still in its NBIRTH window.
+			// Queue the click; the OnPacketRead PUBLISH branch will fire it once
+			// the window has cleared.
+			if !mLogger.firstQualifyingPublishAt.IsZero() {
+				if since := now.Sub(mLogger.firstQualifyingPublishAt); since < nbirthWindow {
+					remaining := nbirthWindow - since
+					mLogger.pendingRebirth = true
+					mLogger.refreshMu.Unlock()
+					log.Printf("Queued user-initiated rebirth; will fire in ~%s once NBIRTH window clears", remaining.Round(time.Second))
+					fmt.Fprintf(w, `<span>The thermostat just connected and is initializing. Your refresh will fire automatically in about %d seconds.</span>`, int(remaining.Round(time.Second).Seconds()))
+					return
+				}
+			}
+
+			// Normal path: fire immediately.
+			mLogger.rebirthLastSent = now
+			mLogger.refreshMu.Unlock()
+			mLogger.sendRebirth()
+			fmt.Fprint(w, `<span>Refresh requested. Full state will arrive over the next ~60 seconds.</span>`)
 		})
 		webControlMux.HandleFunc("/schedule", func(w http.ResponseWriter, r *http.Request) {
 			scheduleHTML, err := RenderSchedule(loadedValues)
@@ -1076,7 +1168,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 	}))
 	level.Set(slog.LevelInfo)
 
-	mLogger := &MQTTLogger{
+	mLogger = &MQTTLogger{
 		server:            server,
 		savedProtosDir:    savedProtosDir,
 		iotMQTTClient:     awsIOTMQTTClient,

--- a/cmd/anantha/cmd/serve.go
+++ b/cmd/anantha/cmd/serve.go
@@ -61,12 +61,43 @@ type MQTTLogger struct {
 
 	liveClients map[string]struct{}
 
-	// State for the user-initiated /refresh-state button. All four fields are
+	// State for the user-initiated /refresh-state button. All five fields are
 	// guarded by refreshMu.
 	refreshMu                sync.Mutex
-	firstQualifyingPublishAt time.Time // zero when no qualifying PUBLISH seen this session
-	pendingRebirth           bool      // user clicked during the firmware NBIRTH window; fire when ready
-	rebirthLastSent          time.Time // last successful sendRebirth, for cooldown
+	firstQualifyingPublishAt time.Time   // zero when no qualifying PUBLISH seen this session
+	pendingRebirth           bool        // user clicked during the firmware NBIRTH window; fire when ready
+	pendingRebirthTimer      *time.Timer // wakes up firePendingRebirth when the NBIRTH window closes
+	rebirthLastSent          time.Time   // last successful sendRebirth, for cooldown
+}
+
+// firePendingRebirth is invoked by pendingRebirthTimer when the NBIRTH window
+// has closed. Re-checks state under the lock because CONNECT may have cleared
+// pendingRebirth, and an explicit /refresh-state click may have updated
+// rebirthLastSent during the wait. Does not log on no-op paths because they're
+// expected operating conditions, not errors.
+func (m *MQTTLogger) firePendingRebirth() {
+	const cooldown = 90 * time.Second
+
+	m.refreshMu.Lock()
+	if !m.pendingRebirth {
+		// CONNECT cleared it (or another path already fired).
+		m.refreshMu.Unlock()
+		return
+	}
+	if !m.rebirthLastSent.IsZero() && time.Since(m.rebirthLastSent) < cooldown {
+		// An explicit click during our wait already fired a rebirth. The
+		// queued one would be redundant - drop it silently.
+		m.pendingRebirth = false
+		m.refreshMu.Unlock()
+		return
+	}
+
+	m.pendingRebirth = false
+	m.rebirthLastSent = time.Now()
+	m.refreshMu.Unlock()
+
+	log.Printf("Firing queued Node Control/Rebirth (NBIRTH window cleared)")
+	m.sendRebirth()
 }
 
 // sendRebirth publishes a Sparkplug B "Node Control/Rebirth" = true command on
@@ -140,18 +171,7 @@ func (m *MQTTLogger) OnPacketRead(cl *mqtt.Client, pk packets.Packet) (packets.P
 			if m.firstQualifyingPublishAt.IsZero() {
 				m.firstQualifyingPublishAt = time.Now()
 			}
-			// If a /refresh-state click queued a rebirth while we were still in
-			// the firmware's NBIRTH window, fire it now if enough time has passed.
-			shouldFirePending := m.pendingRebirth && time.Since(m.firstQualifyingPublishAt) >= 120*time.Second
-			if shouldFirePending {
-				m.pendingRebirth = false
-				m.rebirthLastSent = time.Now()
-			}
 			m.refreshMu.Unlock()
-			if shouldFirePending {
-				log.Printf("Firing queued Node Control/Rebirth (NBIRTH window cleared)")
-				m.sendRebirth()
-			}
 		}
 		protoFilename := fmt.Sprintf("%s-%s.pb", strings.ReplaceAll(string(pk.TopicName), "/", "_"), time.Now().Format(time.RFC3339Nano))
 		if err := os.WriteFile(
@@ -228,12 +248,17 @@ func (m *MQTTLogger) OnPacketRead(cl *mqtt.Client, pk packets.Packet) (packets.P
 		// New MQTT session - clear refresh-button state from the prior session.
 		// firstQualifyingPublishAt will be re-set on the next qualifying PUBLISH
 		// (the first NDATA on the thingname-suffixed topic). pendingRebirth was
-		// queued by a click against the old session, so it's no longer valid.
+		// queued by a click against the old session, so it's no longer valid;
+		// stop its timer to avoid firing into the new session at the wrong time.
 		// rebirthLastSent intentionally survives the reconnect so the cooldown
 		// can't be bypassed by power-cycling the thermostat.
 		m.refreshMu.Lock()
 		m.firstQualifyingPublishAt = time.Time{}
 		m.pendingRebirth = false
+		if m.pendingRebirthTimer != nil {
+			m.pendingRebirthTimer.Stop()
+			m.pendingRebirthTimer = nil
+		}
 		m.refreshMu.Unlock()
 	case packets.Pingreq:
 		// Don't log PINGREQ
@@ -819,12 +844,20 @@ func runServe(cmd *cobra.Command, args []string) error {
 			}
 
 			// Subcase B: thermostat is connected but still in its NBIRTH window.
-			// Queue the click; the OnPacketRead PUBLISH branch will fire it once
-			// the window has cleared.
+			// Queue the click and set a one-shot timer that wakes up when the
+			// window closes. A re-click during the wait stops the previous
+			// timer and starts a new one (still bounded to one fire). CONNECT
+			// stops the timer entirely since the click was for the prior session.
 			if !mLogger.firstQualifyingPublishAt.IsZero() {
 				if since := now.Sub(mLogger.firstQualifyingPublishAt); since < nbirthWindow {
 					remaining := nbirthWindow - since
 					mLogger.pendingRebirth = true
+					if mLogger.pendingRebirthTimer != nil {
+						mLogger.pendingRebirthTimer.Stop()
+					}
+					// Wait a small extra beat past the window so we're clearly
+					// past it (and so jitter doesn't put us right at the edge).
+					mLogger.pendingRebirthTimer = time.AfterFunc(remaining+2*time.Second, mLogger.firePendingRebirth)
 					mLogger.refreshMu.Unlock()
 					log.Printf("Queued user-initiated rebirth; will fire in ~%s once NBIRTH window clears", remaining.Round(time.Second))
 					fmt.Fprintf(w, `<span>The thermostat just connected and is initializing. Your refresh will fire automatically in about %d seconds.</span>`, int(remaining.Round(time.Second).Seconds()))

--- a/cmd/anantha/cmd/state_complete.go
+++ b/cmd/anantha/cmd/state_complete.go
@@ -1,0 +1,83 @@
+package cmd
+
+import "fmt"
+
+// stateLooksComplete returns true when LoadedValues looks like it has
+// roughly the data a fully-populated install would carry: node-level
+// metadata, plus per-active-zone schedule and activity coverage. Used by
+// the index renderer to decide whether to suggest a refresh in the button
+// pre-text.
+//
+// "Active zone" is detected via live state metrics (rt/htsp/clsp), not the
+// <N>/enabled flag. Zone 1 has no /enabled field at all on a single-zone
+// install, but does have live state. Disabled zones (2-8 on a single-zone
+// install) have schedule/activity definitions but no live state, so we skip
+// them here.
+//
+// The heuristic is deliberately permissive: requiring "at least one period
+// per day" rather than "all 5" so that a thermostat configured with fewer
+// than 5 periods doesn't get falsely flagged as incomplete.
+func stateLooksComplete(lv *LoadedValues) bool {
+	snap := lv.Snapshot()
+
+	has := func(key string) bool {
+		_, ok := snap[key]
+		return ok
+	}
+
+	// Node-level metrics that always exist on a fully-populated install.
+	nodeKeys := []string{
+		"system/mode", "system/oat",
+		"sensor/wallControl/rt", "sensor/wallControl/rh",
+		"profile/model", "profile/firmware", "profile/brand", "profile/serial",
+	}
+	for _, k := range nodeKeys {
+		if !has(k) {
+			return false
+		}
+	}
+
+	days := []string{"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"}
+	activities := []string{"home", "away", "sleep", "wake", "manual"}
+
+	foundActiveZone := false
+	for n := 1; n <= 8; n++ {
+		zone := fmt.Sprintf("%d", n)
+
+		// Active-zone signal: live state metrics present.
+		if !has(zone+"/rt") || !has(zone+"/htsp") || !has(zone+"/clsp") {
+			continue
+		}
+		foundActiveZone = true
+
+		// Each day must have at least one fully-formed period.
+		for _, day := range days {
+			anyPeriod := false
+			for p := 1; p <= 5; p++ {
+				base := fmt.Sprintf("%s/program/%s/period %d", zone, day, p)
+				if has(base+"/time") && has(base+"/activity") && has(base+"/enabled") {
+					anyPeriod = true
+					break
+				}
+			}
+			if !anyPeriod {
+				return false
+			}
+		}
+
+		// At least 4 of 5 activities must have htsp set. The 4-of-5 threshold
+		// allows for a user-disabled activity slot.
+		actCount := 0
+		for _, a := range activities {
+			if has(fmt.Sprintf("%s/activities/%s/htsp", zone, a)) {
+				actCount++
+			}
+		}
+		if actCount < 4 {
+			return false
+		}
+	}
+
+	// Sanity: at least one zone must be active.
+	return foundActiveZone
+}

--- a/cmd/anantha/cmd/templates.go
+++ b/cmd/anantha/cmd/templates.go
@@ -42,10 +42,18 @@ func init() {
 	}
 }
 
+// IndexData holds data for the index/dashboard template
+type IndexData struct {
+	StateComplete bool
+}
+
 // RenderIndex renders the index/dashboard template
-func RenderIndex() (string, error) {
+func RenderIndex(loadedValues *LoadedValues) (string, error) {
+	data := IndexData{
+		StateComplete: stateLooksComplete(loadedValues),
+	}
 	var buf bytes.Buffer
-	if err := indexTemplate.Execute(&buf, nil); err != nil {
+	if err := indexTemplate.Execute(&buf, data); err != nil {
 		return "", fmt.Errorf("failed to execute index template: %w", err)
 	}
 	return buf.String(), nil

--- a/cmd/anantha/cmd/templates/index.html
+++ b/cmd/anantha/cmd/templates/index.html
@@ -216,6 +216,36 @@
 		.notifications-container > div:empty {
 			display: none;
 		}
+
+		.refresh-state-row {
+			display: flex;
+			align-items: center;
+			gap: 12px;
+			flex-wrap: wrap;
+			margin: 10px 0 20px 0;
+			font-size: 0.9rem;
+			color: var(--secondary);
+		}
+
+		.refresh-state-row button {
+			background-color: var(--primary);
+			color: white;
+			border: none;
+			padding: 8px 14px;
+			border-radius: var(--border-radius);
+			font-size: 0.9rem;
+			font-weight: 500;
+			cursor: pointer;
+			transition: var(--transition);
+		}
+
+		.refresh-state-row button:hover {
+			background-color: var(--primary-dark);
+		}
+
+		.refresh-state-row .error {
+			color: var(--danger);
+		}
 	</style>
 </head>
 <body>
@@ -259,6 +289,15 @@
 			<div class="last-updated">
 				Last updated: <span id="last-updated-text" sse-swap="last-updated">Never</span>
 				<span id="connection-status" class="connection-status connected">Connected</span>
+			</div>
+			<div class="refresh-state-row">
+				{{if .StateComplete}}
+				<span>Schedule and profile data are already loaded. You can refresh anyway:</span>
+				{{else}}
+				<span>Schedule and profile data look incomplete. Click to request a full state refresh from the thermostat.</span>
+				{{end}}
+				<button hx-post="/refresh-state" hx-target="#refresh-status" hx-swap="innerHTML">Refresh thermostat state</button>
+				<span id="refresh-status"></span>
 			</div>
 			<!-- System Overview Card -->
 			<div class="section-title">System Overview</div>


### PR DESCRIPTION

## What

Fresh anantha installs (and any with an empty proto cache) used to render an empty `/schedule` and mostly-empty `/profiles` until the user manually edited every field on the thermostat. The cause: after CONNECT, the thermostat publishes only deltas, not a full snapshot. Wifi cycling does not trigger a republish either.

This PR adds a "Refresh thermostat state" button to the dashboard. Clicking it sends a Sparkplug B `Node Control/Rebirth = true` (CT_BOOL) command to `spBv1.0/WallCtrl/NCMD/<clientID>`. The firmware honors this and dumps full state (~2200 entries: schedule, activity setpoints, system info, sensor templates), populating the dashboard within roughly a minute.

The button's pre-text changes based on a per-page-load completeness check (`stateLooksComplete` in `cmd/anantha/cmd/state_complete.go`) so the user can see whether a refresh is likely useful, but the button itself stays clickable in either case.

## Why a button instead of auto-fire on connect

Earlier revisions of this PR fired the rebirth automatically 120s after the first qualifying PUBLISH per session. @anupcshan flagged a concern in review: if anantha crashes processing the rebirth response, an unconditional auto-fire restarts the loop on every recovery. A user-initiated button avoids that entirely while still solving the headline "first page load is empty after a fresh install" problem.

## Handler behavior

The handler (`POST /refresh-state`) picks one of four paths in order:

- **Immediate fire**: call `sendRebirth()`, record `rebirthLastSent` for the cooldown gate.
- **Cooldown** (last successful send within 90s): return remaining seconds. 90s is padded above the empirically observed ~59s response window; see the timing table below.
- **Subcase A** (thermostat not connected): `liveClients` is empty, so the publish would land at the broker with no subscriber. Short-circuit with a clear message.
- **Subcase B** (thermostat connected but still in its 120s NBIRTH window): the firmware silently drops rebirths during this window. Set `pendingRebirth=true` and arm a `time.AfterFunc` timer that fires `sendRebirth()` once the window clears. The timer callback re-checks both `pendingRebirth` (cleared on CONNECT) and the cooldown before publishing.

State guarded by a `refreshMu` mutex on `MQTTLogger`. The queue and timer are cleared on CONNECT (so a click from the prior session does not bleed into the new one), and `pendingRebirth` is in-memory only, so an anantha crash clears the queue on restart.

## Empirical timing data

Verified against `SYSTXCCITC01-C` running v2.00 (build `131755-02.00`). One rebirth response, measured T+ from the `Sent Node Control/Rebirth` log line to each PUBLISH log line:

| T+ from Sent | Topic | Size |
|---|---|---:|
| +6.6s | `spBv1.0/WallCtrl/NBIRTH/<id>` | 30.7 KB |
| +15.9s | `spBv1.0/WallCtrl/DBIRTH/<id>/energy_star` | 18.8 KB |
| +23.8s | `spBv1.0/WallCtrl/DBIRTH/<id>/idu` | 0.8 KB |
| +32.1s | `spBv1.0/WallCtrl/DBIRTH/<id>/odu` | 1.9 KB |
| +43.3s | `spBv1.0/WallCtrl/DBIRTH/<id>/zones` | **44.3 KB** |
| +51.0s | `spBv1.0/WallCtrl/DBIRTH/<id>/debug` | 0.8 KB |
| +59.3s | `spBv1.0/WallCtrl/DBIRTH/<id>/energy` | 3.2 KB |

Total payload: ~99.6 KB across 7 publishes over 59 seconds. The 90-second cooldown is padded above this. The `DBIRTH/zones` payload at 44 KB is the largest by far - that's where the schedule (`1/program/...`) and activity setpoints (`1/activities/...`) live.

## Completeness heuristic

`stateLooksComplete` checks node-level metrics (`system/mode`, `system/oat`, `sensor/wallControl/{rt,rh}`, `profile/{model,firmware,brand,serial}`) plus a per-active-zone schedule and activity check. Notes:

- Active zones are detected via live state metrics (`rt`/`htsp`/`clsp`), not the `<N>/enabled` flag, because zone 1 on a single-zone install has no `enabled` field at all (verified against actual DBIRTH decodes).
- The schedule check requires at least one fully-formed `time + activity + enabled` triple per day rather than all five periods, so a thermostat with fewer than 5 configured periods isn't falsely flagged.
- The activity check requires 4 of 5 activities (`home`, `away`, `sleep`, `wake`, `manual`) to have `htsp` set, leaving room for one user-disabled activity slot.

If real installs report false-positives or false-negatives, the metric set is the natural place to tune.

## End-to-end verification

Tested against the live deployment on 2026-05-11. anantha running in Docker with `--reqs-dir` pointing at a host-mounted volume. The host directory was wiped before container start to give a true cold-start with no on-disk proto cache.

Container logs (some noise omitted):

```
18:35:14 serve.go:735: Done loading all proto messages
18:35:14 serve.go:1464: Listening for interrupt signals
18:35:30 serve.go:205: SUBSCRIBE from 2025W205449: spBv1.0/WallCtrl/NCMD/2025W205449
18:35:31-37 SUBSCRIBE energy_star, idu, odu, zones, debug, energy
18:35:42 serve.go:164: PUBLISH from 2025W205449: spBv1.0/WallCtrl/NDATA/2025W205449 [len: 1729]
18:36:11 serve.go:862: Queued user-initiated rebirth; will fire in ~1m31s once NBIRTH window clears
18:37:44 serve.go:99:  Firing queued Node Control/Rebirth (NBIRTH window cleared)
18:37:44 serve.go:131: Sent Node Control/Rebirth to spBv1.0/WallCtrl/NCMD/2025W205449
18:37:51 serve.go:164: PUBLISH from 2025W205449: spBv1.0/WallCtrl/NBIRTH/2025W205449 [len: 30792]
18:38:00 serve.go:164: PUBLISH ...DBIRTH/.../energy_star [len: 18790]
18:38:08 serve.go:164: PUBLISH ...DBIRTH/.../idu        [len:   817]
18:38:17 serve.go:164: PUBLISH ...DBIRTH/.../odu        [len:  1891]
18:38:28 serve.go:164: PUBLISH ...DBIRTH/.../zones      [len: 44350]
18:38:36 serve.go:164: PUBLISH ...DBIRTH/.../debug      [len:   844]
18:38:44 serve.go:164: PUBLISH ...DBIRTH/.../energy     [len:  3176]
18:41:01 serve.go:131: Sent Node Control/Rebirth to spBv1.0/WallCtrl/NCMD/2025W205449
18:41:08 serve.go:164: PUBLISH ...NBIRTH... [len: 30792]
```

What this exercises:

- **Subcase B (queue):** `POST /refresh-state` at 18:36:11, mid NBIRTH window. Handler returned "fire automatically in about 91 seconds". Timer fired at 18:37:44 (queue + 2s buffer). Full state drained by 18:38:44.
- **Warm-state immediate fire:** `POST /refresh-state` at 18:41:01 (cooldown elapsed). Handler returned "Refresh requested. Full state will arrive over the next ~60 seconds." Single `Sent Node Control/Rebirth` log line; response began landing 7s later.
- **Cooldown gate:** a third click immediately after returned "Please wait 90 seconds before refreshing again." No log line - gate hit before publish.
- **Subcase A:** tested earlier in the boot window before the thermostat first published. Handler returned "The thermostat is not connected to anantha yet. Please wait for it to publish before requesting a refresh."

`LoadedValues` settled at 2230 entries by 18:38:44. Exactly one `Sent Node Control/Rebirth` per fire across the whole sequence; no double-fires from the AfterFunc timer.

## Related

- #16 (also a state-rendering issue, partially fixed upstream via `OnChangeN`; this PR addresses the orthogonal problem of the thermostat not publishing the data in the first place).

## Compatibility table

Adds `SYSTXCCITC01-C / v2.00` as a new known-working configuration. The rebirth approach should work on any firmware that uses Sparkplug B-shaped topics.
