### PR TITLE
Pin GitHub Actions to commit SHAs and bump to Node 24-compatible versions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version-file: 'go.mod'
 
@@ -29,11 +29,11 @@ jobs:
       run: go test -v ./...
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
     - name: Log in to Container Registry
       if: github.event_name != 'pull_request'
-      uses: docker/login-action@v3
+      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
@@ -41,7 +41,7 @@ jobs:
 
     - name: Extract metadata
       id: meta
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
       with:
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
         tags: |
@@ -53,7 +53,7 @@ jobs:
 
     - name: Build and push Docker image
       id: build
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
       with:
         context: .
         platforms: linux/amd64,linux/arm64

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,8 +13,8 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: 'go.mod'
       - name: Check formatting


### PR DESCRIPTION

## What

GitHub deprecated Node.js 20 actions ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). Both workflows currently emit a deprecation warning on every run:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: `actions/checkout@v4`, `actions/setup-go@v5`. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.

This PR upgrades all six referenced actions to their latest majors, all of which run on Node.js 24, and pins each to a commit SHA so we have an immutable reference.

## Pinning to SHAs

Pinning by tag (`@v6`) means the tag could be moved by a compromised maintainer or a takeover of the action's repo. Pinning by commit SHA (`@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2`) means the action ref is immutable - GitHub will refuse to run anything else under that ref.

This is the [GitHub-recommended hardening](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) for third-party actions and is consistent with what `dependabot` produces when it bumps action versions.

The `# vX.Y.Z` trailing comment keeps the version readable in code review.

## Version table

| Action | Old | New | Risk |
|---|---|---|---|
| `actions/checkout` | v4 | v6.0.2 | low - internal credential-handling refactor; default usage transparent |
| `actions/setup-go` | v5 | v6.4.0 | low - sets `GOTOOLCHAIN=local`, safe for our `go 1.25.4` go.mod with no `toolchain` directive |
| `docker/setup-buildx-action` | v3 | v4.0.0 | low - removes deprecated `config`, `config-inline`, `install` inputs (we use none) |
| `docker/login-action` | v3 | v4.1.0 | low - Node 24 + ESM rewrite, no breaking API changes |
| `docker/metadata-action` | v5 | v6.0.0 | low - `#` parsing change in tag values (we have no `#` in our tags) |
| `docker/build-push-action` | v5 | v7.1.0 | low-medium - now generates a build summary in the Actions UI by default; opt out via `DOCKER_BUILD_SUMMARY: false` if undesired |

## Notes for review

- The build summary (new in `docker/build-push-action@v6+`) is purely additive to the GitHub Actions UI - no behavior change in what gets pushed to ghcr or how. If the maintainer prefers to suppress it, add `DOCKER_BUILD_SUMMARY: false` to the env block.
- I did not bump the runner from `ubuntu-latest`; the v2.327.1+ runner version requirement stated in the action release notes is already covered by `ubuntu-latest`.
- Each bump's release notes were skimmed individually for breaking changes. The full per-action analysis is in the commit history if needed.

## Verification

The CI ran the new versions on the PR itself - if this PR's lint and docker-build jobs both pass green, the upgrade has succeeded. If anything fails, the per-action breaking-change notes above are the place to start.
