### PR TITLE
Register Carrier as a proper Home Assistant device, plus a one-time discovery cleanup subcommand

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -26,7 +26,7 @@ ghcr.io/anupcshan/anantha:<branch>-<commit-sha>
 docker pull ghcr.io/anupcshan/anantha:latest
 ```
 
-### Run the container
+### Run the server (`serve`)
 ```bash
 docker run -p 53:53/udp -p 53:53/tcp -p 80:80 -p 443:443 -p 8883:8883 -p 26268:26268 \
   ghcr.io/anupcshan/anantha:latest serve \
@@ -37,6 +37,32 @@ docker run -p 53:53/udp -p 53:53/tcp -p 80:80 -p 443:443 -p 8883:8883 -p 26268:2
   --ha-mqtt-password <HA_MQTT_PASSWORD> \
   --client-id <THERMOSTAT_DEVICE_ID> \
   --external-ip-override <DOCKER_HOST_IP> # Optional
+```
+
+### Patch firmware (`edit-firmware`)
+
+The image also bundles the `edit-firmware` subcommand for patching thermostat firmware files. Run as a one-shot, mounting the host directory containing the input/output hex files:
+
+```bash
+docker run --rm \
+  -v /path/to/firmware:/firmware \
+  ghcr.io/anupcshan/anantha:latest edit-firmware \
+  -in /firmware/BINF0456.hex \
+  -out /firmware/BINF0456.patched.hex
+```
+
+`--rm` makes the container transient; the bind mount lets the patched output land back on the host.
+
+### Clear stale HA discovery (`reset-ha-discovery`)
+
+One-time migration helper for users upgrading from a version of anantha before the `device` block was added to Home Assistant MQTT discovery. See the "Upgrading" section in the main README for context. Stop the running `anantha serve` container first, run this one-shot, then start `serve` again.
+
+```bash
+docker run --rm ghcr.io/anupcshan/anantha:latest reset-ha-discovery \
+  --ha-mqtt-addr <HA_MQTT_IP>:1883 \
+  --ha-mqtt-username <HA_MQTT_USERNAME> \
+  --ha-mqtt-password <HA_MQTT_PASSWORD> \
+  --client-id <THERMOSTAT_DEVICE_ID>
 ```
 
 ### Docker Compose Example
@@ -62,6 +88,24 @@ services:
       --client-id YOUR_THERMOSTAT_ID
       --external-ip-override DOCKER_HOST_IP
     restart: unless-stopped
+```
+
+To run the one-shot subcommands against the same compose service definition, use `docker compose run --rm` and override the command. Stop the long-running `anantha` service first when running `reset-ha-discovery`.
+
+```bash
+# Patch firmware via compose:
+docker compose run --rm \
+  -v /path/to/firmware:/firmware \
+  anantha edit-firmware -in /firmware/BINF0456.hex -out /firmware/BINF0456.patched.hex
+
+# Clear stale HA discovery via compose (stop the service first):
+docker compose stop anantha
+docker compose run --rm anantha reset-ha-discovery \
+  --ha-mqtt-addr 192.168.1.100:1883 \
+  --ha-mqtt-username HA_MQTT_USERNAME \
+  --ha-mqtt-password HA_MQTT_PASSWORD \
+  --client-id YOUR_THERMOSTAT_ID
+docker compose up -d anantha
 ```
 
 ## Building Locally

--- a/README.md
+++ b/README.md
@@ -29,9 +29,10 @@ Install the anantha CLI tool:
 go install github.com/anupcshan/anantha/cmd/anantha@latest
 ```
 
-This installs a single binary `anantha` in your `$GOBIN` (typically `$HOME/go/bin`) with two main subcommands:
+This installs a single binary `anantha` in your `$GOBIN` (typically `$HOME/go/bin`) with three subcommands:
 - `anantha serve`: The main server handling HTTP/MQTT communication
 - `anantha edit-firmware`: A tool for patching firmware with the CA certificate
+- `anantha reset-ha-discovery`: A one-time helper for clearing a stale Home Assistant MQTT discovery message (see [Upgrading](#upgrading) below)
 
 ## Setup Instructions
 
@@ -59,6 +60,24 @@ anantha serve \
 ### 3. Configure Thermostat
 
 Set your thermostat's DNS Server to Anantha's IP address.
+
+## Upgrading
+
+### HA discovery cleanup (one-time, only for users upgrading from before device discovery)
+
+If you ran a previous version of anantha that did not include a `device` block in its Home Assistant MQTT discovery payload, your existing climate entity in HA is registered without a device association. After upgrading, the new payload registers a device card correctly but HA does not auto-attach the existing entity to it - you'll see a "Carrier Infinity" device with "no entities" while the orphaned entity remains in HA's Ungrouped list.
+
+Fix this once after upgrading by stopping `anantha serve`, running the cleanup subcommand, then starting `anantha serve` again. The cleanup publishes an empty retained payload to `homeassistant/climate/<CLIENT_ID>/config`, which causes HA to remove the orphaned entity registration. The next `anantha serve` start republishes discovery with the device block, and HA registers the entity fresh against the device.
+
+```bash
+anantha reset-ha-discovery \
+  --ha-mqtt-addr <HA_MQTT_IP>:1883 \
+  --ha-mqtt-username <HA_MQTT_USERNAME> \
+  --ha-mqtt-password <HA_MQTT_PASSWORD> \
+  --client-id <THERMOSTAT_DEVICE_ID>
+```
+
+This is safe to run on a fresh install or an already-migrated install: HA's entity will disappear briefly and reappear with the device association on the next `anantha serve` start.
 
 ## Features
 

--- a/cmd/anantha/cmd/hamqtt.go
+++ b/cmd/anantha/cmd/hamqtt.go
@@ -360,6 +360,27 @@ func (h *HAMQTT) Run() {
 	log.Printf("Connected to %s", h.addr)
 
 	h.loadedValues.OnChange1("profile/serial", func(tv TimestampedValue) {
+		// Pull device metadata from LoadedValues if present. These are usually
+		// populated alongside profile/serial but not guaranteed on cold start;
+		// missing fields are omitted from the JSON so HA falls back to defaults
+		// rather than showing empty strings.
+		deviceField := func(key string) string {
+			v := h.loadedValues.Get(key)
+			if v.value == nil {
+				return ""
+			}
+			return string(v.value.GetMaybeStrValue())
+		}
+		serial := string(tv.value.GetMaybeStrValue())
+
+		type haDevice struct {
+			Identifiers  []string `json:"identifiers"`
+			Name         string   `json:"name"`
+			Manufacturer string   `json:"manufacturer,omitempty"`
+			Model        string   `json:"model,omitempty"`
+			SWVersion    string   `json:"sw_version,omitempty"`
+		}
+
 		discoveryMsg := struct {
 			Name                        string   `json:"name"`
 			ActionTopic                 string   `json:"action_topic"`
@@ -378,6 +399,7 @@ func (h *HAMQTT) Run() {
 			ModeStateTopic              string   `json:"mode_state_topic"`
 			Modes                       []string `json:"modes"`
 			UniqueID                    string   `json:"unique_id"`
+			Device                      haDevice `json:"device"`
 		}{
 			Name:                        "carrier",
 			ActionTopic:                 fmt.Sprintf("%s/action/current", h.topicPrefix),
@@ -396,6 +418,13 @@ func (h *HAMQTT) Run() {
 			ModeStateTopic:              fmt.Sprintf("%s/mode/current", h.topicPrefix),
 			Modes:                       []string{"auto", "off", "cool", "heat", "fan_only"},
 			UniqueID:                    h.clientID,
+			Device: haDevice{
+				Identifiers:  []string{serial},
+				Name:         "Carrier Infinity",
+				Manufacturer: deviceField("profile/brand"),
+				Model:        deviceField("profile/model"),
+				SWVersion:    deviceField("profile/firmware"),
+			},
 		}
 		discoveryMsgJSON, err := json.Marshal(discoveryMsg)
 		if err != nil {

--- a/cmd/anantha/cmd/reset_ha_discovery.go
+++ b/cmd/anantha/cmd/reset_ha_discovery.go
@@ -1,0 +1,84 @@
+package cmd
+
+import (
+	"fmt"
+	"time"
+
+	mqtt_paho "github.com/eclipse/paho.mqtt.golang"
+	"github.com/spf13/cobra"
+)
+
+var resetHADiscoveryCmd = &cobra.Command{
+	Use:   "reset-ha-discovery",
+	Short: "Clear the retained Home Assistant MQTT discovery message",
+	Long: `Publish an empty retained payload to homeassistant/climate/<clientID>/config so
+Home Assistant removes the existing climate entity registration. After this runs,
+restart 'anantha serve' (or wait for the next thermostat reconnect) to republish
+the discovery message; HA will register the entity fresh.
+
+This is a one-time migration step for users upgrading from a version of anantha
+that did not include the 'device' block in the discovery payload. After upgrading,
+HA will not auto-attach the existing entity to the new device record, leaving a
+device card with "no entities". Running this subcommand and then restarting
+'anantha serve' resolves the orphaned state.
+
+Run this while 'anantha serve' is stopped, otherwise the running bridge may
+republish discovery before HA has had time to remove the entity.
+
+Example:
+  anantha reset-ha-discovery \
+    --ha-mqtt-addr 192.168.1.100:1883 \
+    --ha-mqtt-username myuser \
+    --ha-mqtt-password mypass \
+    --client-id 4123X123456`,
+	RunE: runResetHADiscovery,
+}
+
+func init() {
+	resetHADiscoveryCmd.Flags().String("ha-mqtt-addr", "", "Home Assistant MQTT host:port (required, e.g. 192.168.1.100:1883)")
+	resetHADiscoveryCmd.Flags().String("ha-mqtt-username", "", "Home Assistant MQTT username")
+	resetHADiscoveryCmd.Flags().String("ha-mqtt-password", "", "Home Assistant MQTT password")
+	resetHADiscoveryCmd.Flags().String("client-id", "", "Thermostat Device Serial ID (required)")
+	//nolint:errcheck
+	resetHADiscoveryCmd.MarkFlagRequired("ha-mqtt-addr")
+	//nolint:errcheck
+	resetHADiscoveryCmd.MarkFlagRequired("client-id")
+}
+
+func runResetHADiscovery(cmd *cobra.Command, args []string) error {
+	addr, _ := cmd.Flags().GetString("ha-mqtt-addr")
+	username, _ := cmd.Flags().GetString("ha-mqtt-username")
+	password, _ := cmd.Flags().GetString("ha-mqtt-password")
+	clientID, _ := cmd.Flags().GetString("client-id")
+
+	topic := fmt.Sprintf("homeassistant/climate/%s/config", clientID)
+
+	opts := mqtt_paho.NewClientOptions().
+		AddBroker(fmt.Sprintf("tcp://%s", addr)).
+		SetClientID(fmt.Sprintf("anantha-reset-%d", time.Now().Unix())).
+		SetConnectTimeout(10 * time.Second)
+	if username != "" {
+		opts.SetUsername(username)
+	}
+	if password != "" {
+		opts.SetPassword(password)
+	}
+
+	client := mqtt_paho.NewClient(opts)
+	if token := client.Connect(); token.Wait() && token.Error() != nil {
+		return fmt.Errorf("failed to connect to MQTT broker at %s: %w", addr, token.Error())
+	}
+	defer client.Disconnect(250)
+
+	token := client.Publish(topic, 0, true, []byte(""))
+	if !token.WaitTimeout(10 * time.Second) {
+		return fmt.Errorf("timed out waiting for publish to %s", topic)
+	}
+	if err := token.Error(); err != nil {
+		return fmt.Errorf("failed to publish to %s: %w", topic, err)
+	}
+
+	fmt.Printf("Cleared retained HA discovery message at %s.\n", topic)
+	fmt.Println("Restart 'anantha serve' or wait for the next thermostat reconnect to republish discovery with the device association.")
+	return nil
+}

--- a/cmd/anantha/cmd/root.go
+++ b/cmd/anantha/cmd/root.go
@@ -26,4 +26,5 @@ func Execute() {
 func init() {
 	rootCmd.AddCommand(serveCmd)
 	rootCmd.AddCommand(editFirmwareCmd)
+	rootCmd.AddCommand(resetHADiscoveryCmd)
 }


### PR DESCRIPTION

## What

The HA MQTT discovery payload anantha publishes was missing a `device` field. Without it, Home Assistant registers the climate entity but cannot attach it to a device record - the entity ends up "Ungrouped" with no Device association under the MQTT integration's Devices view, and the integration's Devices list doesn't show a Carrier entry at all.

This PR adds a `device` block populated from `LoadedValues` fields the thermostat already publishes:

- `device.identifiers` from `profile/serial` (which already triggers the discovery callback).
- `device.name`: hardcoded "Carrier Infinity".
- `device.manufacturer` from `profile/brand`.
- `device.model` from `profile/model`.
- `device.sw_version` from `profile/firmware`.

The three optional fields use `omitempty` so a cold start where those keys haven't arrived yet still produces a valid discovery payload, just without those decorative attributes. The next rebirth or restart fills them in.

## Upgrade hazard and the new `reset-ha-discovery` subcommand

There's a subtle upgrade behavior worth understanding: HA does not auto-attach existing entities to a new device record when a discovery message is updated. So users who previously ran anantha (with the no-`device` payload) will, after upgrading, see:

- A new "Carrier Infinity" device card under the MQTT integration showing manufacturer/model/firmware...
- ...but with "no entities" attached to it.
- The original climate entity still functioning, but stuck in HA's Ungrouped list with no device association.

The fix is a one-time MQTT cleanup: clear the stale retained discovery message so HA removes the orphaned entity registration, then let the next anantha republish create a fresh entity that's properly linked to the device.

To make that operation easy, this PR adds a third subcommand to the existing CLI binary, mirroring the `edit-firmware` pattern:

```bash
anantha reset-ha-discovery \
  --ha-mqtt-addr <broker>:1883 \
  --ha-mqtt-username <u> \
  --ha-mqtt-password <p> \
  --client-id <thermostat-serial>
```

It connects to the broker, publishes an empty retained payload to `homeassistant/climate/<clientID>/config`, and exits. About 85 lines including help text. Idempotent: running on a fresh or already-migrated install is a harmless brief flicker - the entity is recreated by the next `anantha serve` discovery publish.

## Why a subcommand rather than a debug endpoint or auto-detect

Three alternatives were considered:

- **Documentation only** (just `mosquitto_pub -r -n` in the upgrade notes): zero code, but asks users to install MQTT tooling and copy-paste a command they may not understand.
- **`/debug/*` HTTP endpoint** on the dashboard: triggered via curl, but ships a permanent debug endpoint to production for a one-time concern.
- **Auto-detect on bridge startup**: invisible to users, but adds startup-path complexity, races with the existing immediate discovery publish, and lives in the runtime forever for a one-time migration.

The subcommand path is the smallest production-surface change: it uses the same binary and credentials the user already trusts, follows the existing `edit-firmware` precedent (one-shot offline tool that lives next to the runtime), and stays unused unless explicitly invoked.

## Implementation notes

- `cmd/anantha/cmd/reset_ha_discovery.go` is new. `cmd/anantha/cmd/root.go` registers it alongside `serveCmd` and `editFirmwareCmd`.
- Connection uses paho with the same library and pattern the bridge uses. Required flags: `--ha-mqtt-addr` and `--client-id`. Optional: `--ha-mqtt-username`, `--ha-mqtt-password` (some brokers allow anonymous publish).
- Output prints what was cleared and what to do next:
  ```
  Cleared retained HA discovery message at homeassistant/climate/<CLIENT_ID>/config.
  Restart 'anantha serve' or wait for the next thermostat reconnect to republish discovery with the device association.
  ```
- README.md gains an "Upgrading" section explaining when this matters.
- DOCKER.md gains parallel `docker run` documentation for all three subcommands (`serve`, `edit-firmware`, `reset-ha-discovery`), plus compose-run examples for the two one-shots. The `edit-firmware` docker docs are a small doc-gap fix bundled here for cohesion.

## Testing

Verified end-to-end on `SYSTXCCITC01-C` running v2.00 (build `131755-02.00`) with a real Home Assistant + Mosquitto broker.

**Discovery payload (after the change):**

```json
{
  "name": "carrier",
  "action_topic": "...",
  ...existing fields...
  "unique_id": "<CLIENT_ID>",
  "device": {
    "identifiers": ["<CLIENT_ID>"],
    "name": "Carrier Infinity",
    "manufacturer": "Carrier",
    "model": "SYSTXCCITC01-C",
    "sw_version": "CESR131755-02.00"
  }
}
```

**HA Devices view (after migration):**

The "Carrier Infinity" device appears under Settings -> Devices & Services -> MQTT -> Devices, with Manufacturer "Carrier", Model "SYSTXCCITC01-C", Firmware "CESR131755-02.00", and the climate entity attached.

**Migration flow validated:**

1. Original deployment had the no-`device` payload registered as an Ungrouped entity.
2. Ran `anantha reset-ha-discovery ...` against the broker. HA removed the orphaned entity.
3. Restarted `anantha serve`. New discovery published with the `device` block. HA registered the entity fresh, attached to the new device record.

**Subcommand mechanic verified independently:** seeded a retained payload to a sacrificial topic (`homeassistant/climate/RESET_TEST_FAKE_ID/config`), ran `anantha reset-ha-discovery --client-id RESET_TEST_FAKE_ID ...`, and confirmed via paho subscribe that the retained message was cleared.

## Commits

Three commits, in order:

1. `Include device block in HA MQTT discovery` - the field addition in `hamqtt.go`.
2. `Add reset-ha-discovery subcommand` - the new CLI subcommand and `root.go` registration.
3. `Document reset-ha-discovery and add docker examples for one-shot subcommands` - README and DOCKER.md updates.
