### PR TITLE
Embed IANA timezone database in the binary

### DIFF
--- a/cmd/anantha/main.go
+++ b/cmd/anantha/main.go
@@ -1,6 +1,10 @@
 package main
 
-import "github.com/anupcshan/anantha/cmd/anantha/cmd"
+import (
+	_ "time/tzdata"
+
+	"github.com/anupcshan/anantha/cmd/anantha/cmd"
+)
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
## What

The dashboard's schedule view renders current time using `time.Now().Hour()` and `time.Now().Weekday()` in `cmd/anantha/cmd/templates.go`. On minimal container base images (`debian:bookworm-slim`, `distroless`, `scratch`) the IANA zoneinfo files are not present, so Go's runtime falls back to UTC regardless of what the `TZ` environment variable says. The result is a UTC-rendered schedule grid for users in any other zone, and the notification timestamp formatter at `serve.go:1006` (`t.Local().Format(...)`) is similarly stuck on UTC.

This PR adds a single anonymous import of `time/tzdata` to `cmd/anantha/main.go`. That embeds the IANA zone database into the binary at link time. Users still need to set `TZ` in their environment (e.g. `TZ=America/New_York` in their compose file or via `environment:`), but with the embed the lookup succeeds regardless of base image.

## Why this approach

Three options were considered:

- **Install `tzdata` in the Dockerfile**: works, ~2.6 MB image growth, but only fixes the official Docker image. Users running anantha natively via `go install github.com/anupcshan/anantha/cmd/anantha@latest` still see UTC.
- **Embed `time/tzdata`** (this PR): ~400 KB binary growth, fixes both Docker and native install paths, future-proof against base-image churn (Dockerfile could later switch to `scratch` or `distroless` without breaking timezones).
- **Both**: trivial cost difference, but the embed alone is enough.

The embed-only approach is the minimal change that fixes the broadest set of deployment shapes.

## Verification

Built locally with `go build` and confirmed:

- Binary size: 22.4 MB -> 22.9 MB (+403 KB / +1.8%).
- With `TZ=America/New_York` set, `time.LoadLocation("America/New_York")` succeeds and renders local hour (9 EDT) vs UTC (13). Without `TZ`, behavior is unchanged from main (still UTC).
- All four lint gates pass: `go build`, `go vet`, `go fmt`, `golangci-lint` (0 issues).

## User-facing change

After merging, users who want local-time rendering should set `TZ` in their environment:

```bash
# Native:
TZ=America/New_York anantha serve ...

# Docker compose:
environment:
  - TZ=America/New_York

# Docker run:
docker run -e TZ=America/New_York ... ghcr.io/anupcshan/anantha:latest serve ...
```

Without `TZ` set, behavior is identical to today (UTC). No regression for existing deployments.
